### PR TITLE
New OpenBSD images (7.4 & 7.5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
               <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                   <div class="btn-group">
-                    <a class="btn btn-secondary" role="button" href="https://object-storage.public.mtl1.vexxhost.net/swift/v1/1dbafeefbd4f4c80864414a441e72dd2/bsd-cloud-image.org/images/openbsd/7.4/2024-04-29/ufs/openbsd-7.4-2024-04-29.qcow2">7.4</a>
+                    <a class="btn btn-secondary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.4_2024-05-15-16-35/openbsd-min.qcow2">7.4</a>
                     <a class="btn btn-primary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.5_2024-05-13-15-25/openbsd-min.qcow2">7.5</a>
 
                   </div>

--- a/index.html
+++ b/index.html
@@ -53,8 +53,9 @@
         <div class="row">
           <div class="col-sm-8 col-md-7 py-4">
             <h4 class="text-white">About</h4>
-            <p class="text-white">OpenBSD and NetBSD will resize the root partition during the first boot.</p>
             <p class="text-white">All the images come with a single root partition, and use UFS/FFS filesystem.</p>
+            <p class="text-white">NetBSD will resize the root partition during the first boot.</p>
+            <p class="text-white">OpenBSD is provided with a script (<code>/root/bin/create_partitions.sh</code>) to adapt the partition layout after the first boot. The games and X server sets are not installed to keep the image minimal.</p>
             <p class="text-white">In order to be consistent with Cloud-Init, sudo is enabled by default. On OpenBSD,
               doas is still available and just need to be configured.</p>
             <p class="text-white">Finally, the serial console is enabled by default.</p>
@@ -185,8 +186,8 @@
               <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                   <div class="btn-group">
-                    <a class="btn btn-secondary" role="button" href="https://object-storage.public.mtl1.vexxhost.net/swift/v1/1dbafeefbd4f4c80864414a441e72dd2/bsd-cloud-image.org/images/openbsd/7.3/2023-04-22/ufs/openbsd-7.3-2023-04-22.qcow2">7.3</a>
-                    <a class="btn btn-primary" role="button" href="https://object-storage.public.mtl1.vexxhost.net/swift/v1/1dbafeefbd4f4c80864414a441e72dd2/bsd-cloud-image.org/images/openbsd/7.4/2024-04-29/ufs/openbsd-7.4-2024-04-29.qcow2">7.4</a>
+                    <a class="btn btn-secondary" role="button" href="https://object-storage.public.mtl1.vexxhost.net/swift/v1/1dbafeefbd4f4c80864414a441e72dd2/bsd-cloud-image.org/images/openbsd/7.4/2024-04-29/ufs/openbsd-7.4-2024-04-29.qcow2">7.4</a>
+                    <a class="btn btn-primary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.5_2024-05-13-15-25/openbsd-min.qcow2">7.5</a>
 
                   </div>
                 </div>


### PR DESCRIPTION
New images for OpenBSD 7.4 & 7.5 generated with [build_openbsd_qcow2.sh](https://github.com/hcartiaux/openbsd-cloud-image).

The generation command is: `./build_openbsd_qcow2.sh -r '7.5' --image-file 'openbsd-min.qcow2' --size '2' --disklabel 'custom/disklabel.cloud' --sets '-game*.tgz -x*.tgz' --allow_root_ssh 'no' -b`

I've also regenerated a new OpenBSD 7.4 image in order to be consistent with the "About" section.

The files have been produced via github actions and are hosted in a github release, the build and test process can be seen here:

* 7.4 - https://github.com/hcartiaux/openbsd-cloud-image/actions/runs/9098913448
* 7.5 - https://github.com/hcartiaux/openbsd-cloud-image/actions/runs/9054992630

Note that a checksum file is also available to verify the integrity of the images.

I've tested the "NoCloud" data source in the github action, and manually using terraform and the libvirt provider.

Feel free to adapt this PR and/or re-host the files elsewhere if you prefer :)