### PR TITLE
OpenBSD 7.6 image

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,9 +186,8 @@
               <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
                   <div class="btn-group">
-                    <a class="btn btn-secondary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.4_2024-05-15-16-35/openbsd-min.qcow2">7.4</a>
-                    <a class="btn btn-primary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.5_2024-05-13-15-25/openbsd-min.qcow2">7.5</a>
-
+                    <a class="btn btn-secondary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.5_2024-05-13-15-25/openbsd-min.qcow2">7.5</a>
+                    <a class="btn btn-primary" role="button" href="https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.6_2024-10-08-22-40/openbsd-min.qcow2">7.6</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Note that the installation do not rely anymore on `/etc/rc.local` but on sysv init scripts.

The updated build script will be included in the next cloud-init release ([PR #5790](https://github.com/canonical/cloud-init/pull/5790))