### PR TITLE
images_data.json: Set python interpreter for OpenBSD 7.6

### DIFF
--- a/src/images_data.json
+++ b/src/images_data.json
@@ -70,7 +70,8 @@
         "images": [
           {
             "flavor": "UFS",
-            "url": "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.6_2024-10-08-22-40/openbsd-min.qcow2"
+            "url": "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.6_2024-10-08-22-40/openbsd-min.qcow2",
+            "python_interpreter": "/usr/local/bin/python3"
           }
         ]
       }


### PR DESCRIPTION
See https://github.com/virt-lightning/virt-lightning/pull/321 for context.